### PR TITLE
Upon importation, module only prompts if defaults are invalid, and saves input into memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ for the module.
 Inputs:
 ```
 inputtext -- Required String, is the input text to be vocoded, default None
-encoderpath -- Required encoder path, defaults to the DEFAULT_ENCODER_PATH
-vocoderpath -- Required vocoder path, defaults to the DEFAULT_VOCODER_PATH
-synthesizerpath -- Required synthesizer path, defaults to the DEFAULT_SYNTHESIZER_PATH
+encoderpath -- Required encoder path, defaults to the DEFAULT_ENCODER_PATH if not specified (with original default of None)
+vocoderpath -- Required vocoder path, defaults to the DEFAULT_VOCODER_PATH if not specified (with original default of None)
+synthesizerpath -- Required synthesizer path, defaults to the DEFAULT_SYNTHESIZER_PATH if not specified (with original default of None)
 voiceactor -- Required String, is the path to the audio file to be referenced, Default None
 savepath -- Optional String, is the path to the desired save location and type of vocoded audio output, Default None
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ import rtvc
 
 rtvc.voiceclone(text="hello, world!",voiceactor="/path/to/spoken_voice.mp3")
 ```
+The preFlightChecks will prompt you for the encoder, vocoder and synthesizer models if they
+are not located within the default directory (rtvc/encoder, vocoder, and synthesizer, respectively).
+Once you enter that information, however, the locations are saved in memory and are set as the defaults
+for the module.
 
 ####voiceclone Class:
 Inputs:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ keywords = ['pytorch', 'torch', 'tensorflow', 'machine learning', 'research', "v
 
 setuptools.setup(
     name="voiceCloner",
-    version="0.1.1",
+    version="0.1.2",
     author="Sean Bailey",
     author_email="seanbailey518@gmail.com",
     description="This is a wrapper around the Real Time Voice Cloning project by @Corentinj (https://github.com/CorentinJ/Real-Time-Voice-Cloning)",


### PR DESCRIPTION
Now, upon user using 

`import rtvc`

the system will check the built in default values. (Currently they mean nothing, however they will be used in later improvements for automatic download and installation.)

If the encoder, vocoder and synthesizer models are not found in these default locations, the `preFlightChecks()` will prompt for their locations, storing them in memory for later use. Text can then be vocoded from these new default locations, and still also used with different models on specification. #6 