### PR TITLE
Stop preFlightChecks from running automatically on import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,79 @@
 # Real-Time Voice Cloning Module: voiceCloner
+
 ## Background:
-SV2TTS is a three-stage deep learning framework that allows to create a numerical representation of a voice from a few seconds of audio, and to use it to condition a text-to-speech model trained to generalize to new voices.
 
-If you would like to learn more, I heavily encourage you to visit [Real-Time Voice Cloning](https://github.com/CorentinJ/Real-Time-Voice-Cloning) by @CorentinJ, which I see as brilliant work.
+SV2TTS is a three-stage deep learning framework that allows to create a numerical representation of a voice from a few
+seconds of audio, and to use it to condition a text-to-speech model trained to generalize to new voices.
 
+If you would like to learn more, I heavily encourage you to
+visit [Real-Time Voice Cloning](https://github.com/CorentinJ/Real-Time-Voice-Cloning) by @CorentinJ, which I see as
+brilliant work.
 
-This repository is a module based wrapper around [Real-Time Voice Cloning](https://github.com/CorentinJ/Real-Time-Voice-Cloning). The general idea is to have a simple, importable, Pythonic API to perform programmatic voice cloning tasks with. I very highly recommend checking out the original work, as I cannot take any credit for the initial research and development.
+This repository is a module based wrapper
+around [Real-Time Voice Cloning](https://github.com/CorentinJ/Real-Time-Voice-Cloning). The general idea is to have a
+simple, importable, Pythonic API to perform programmatic voice cloning tasks with. I very highly recommend checking out
+the original work, as I cannot take any credit for the initial research and development.
 
-I attempted to make this as simple to use as possible. In general, you will be able to install it, import it, and vocode a piece of text with any voice you can reference from any audio segment you can find -- including your own voice!
-###Requirements:
+I attempted to make this as simple to use as possible. In general, you will be able to install it, import it, and vocode
+a piece of text with any voice you can reference from any audio segment you can find -- including your own voice!
+
+### Requirements:
 
 Requirements for this module are identical to Real-Time Voice Cloning. Python3.8+.
+
 * Install [PyTorch](https://pytorch.org/get-started/locally/) (>=1.0.1).
 * Install [ffmpeg](https://ffmpeg.org/download.html#get-packages).
 
-###Download Pretrained Models
+### Download Pretrained Models
+
 ~~Download the latest [here](https://github.com/CorentinJ/Real-Time-Voice-Cloning/wiki/Pretrained-models).~~
 
-~~***Currently, you will need to download these models to get this module to function. This is a high priority work in progress to simplify this process.***~~
+~~***Currently, you will need to download these models to get this module to function. This is a high priority work in
+progress to simplify this process.***~~
 
-The current iteration of this code will automatically attempt to download and install the pretrained models into the library's location for you.
-If it is unsuccessful due to permissions issues (say you installed this library with `sudo pip3 install .`), then it will prompt you for the appropriate install location.
+The current iteration of this code will automatically attempt to download and install the pretrained models into the
+library's location for you. If it is unsuccessful due to permissions issues (say you installed this library
+with `sudo pip3 install .`), then it will prompt you for the appropriate install location.
 
-###Installation:
+### Installation:
 
 From the root of this repository, simply run:
+
 ```
 pip3 install .
 ```
 
 This will install voiceCloner into your Python location.
 
-###Useage:
+### Useage:
+
 ```
 import rtvc
-#when loaded, rtvc will run preFlightChecks, which will determine if your system is properly configured, attempt to download and install default models, has appropriate models installed, etc.
-#It will fail if your system is not properly configured, or if you do not have appropriate encoder, vocoder and synthesizer models
+
+#it is highly recommended to run rtvc.preFlightChecks(), determine if your system is properly configured, attempt to download and install default models, has appropriate models installed, etc.
+#preFlightChecks() has the following options:
+#download_models -- Boolean, defaults True, tells function whether or not to automatically download and install default models
+#using_cpu -- Boolean, defaults False, flag of function to configure CPU or GPU (or to try with GPU at all)
+#mp3support -- Boolean, defaults True (but checks anyways), flag to check for / confirm mp3 support
+#encoderpath -- String, defaults to the DEFAULT_ENCODER_PATH, set to your encoder model path
+#vocoderpath -- String, defaults to the DEFAULT_VOCODER_PATH, set to your vocoder model path
+#synthpath -- String, defaults to the DEFAULT_SYNTHESIZER_PATH, set to your synthesizer path
+
+rtvc.preFlightChecks()
+
 #you will know if all systems check out if you see
 #"Done."
+
 rtvc.voiceclone(text="hello, world!",voiceactor="/path/to/spoken_voice.mp3")
 ```
-The preFlightChecks will prompt you for the encoder, vocoder and synthesizer models if they
-are not located within the default directory (rtvc/encoder, vocoder, and synthesizer, respectively).
-Once you enter that information, however, the locations are saved in memory and are set as the defaults
-for the module.
 
-####voiceclone Class:
+Once preFlightChecks gets a valid encoder/vocoder/synthesizer model location, then for this session it will save it as
+the default locations, providing easy reference.
+
+#### voiceclone Class:
+
 Inputs:
+
 ```
 inputtext -- Required String, is the input text to be vocoded, default None
 encoderpath -- Required encoder path, defaults to the DEFAULT_ENCODER_PATH if not specified (with original default of None)
@@ -56,7 +83,9 @@ voiceactor -- Required String, is the path to the audio file to be referenced, D
 savepath -- Optional String, is the path to the desired save location and type of vocoded audio output, Default None
 
 ```
+
 Outputs:
+
 ```
 
 generated_wav -- the generated vocoded wav as raw bytecode. Can be accessed directly, ideally by the soundfile module

--- a/rtvc/__init__.py
+++ b/rtvc/__init__.py
@@ -36,7 +36,7 @@ DEFAULT_SYNTHESIZER_PATH = dir_path + "/synthesizer/saved_models/pretrained/pret
 
 
 # we just want to reutrn the audio -- not necessarily play it. No need to check if audio devices exist!
-def preFlightChecks(download_models=True, using_cpu=False, mp3support=SUPPORT_MP3, encoderpath=DEFAULT_ENCODER_PATH,
+def preFlightChecks(download_models=True, using_cpu=USE_CPU, mp3support=SUPPORT_MP3, encoderpath=DEFAULT_ENCODER_PATH,
                     synthpath=DEFAULT_SYNTHESIZER_PATH,
                     vocoderpath=DEFAULT_SYNTHESIZER_PATH):
     global DEFAULT_SYNTHESIZER_PATH
@@ -238,5 +238,4 @@ class voiceclone:
         # sf.write(filename, generated_wav.astype(np.float32), synthesizer.sample_rate)
         # print("\nSaved output as %s\n\n" % filename)
 
-
-preFlightChecks()
+# preFlightChecks()


### PR DESCRIPTION
This stops preFlightChecks from running automatically on import, provides documentation on how the function operates, and encourages the user to run it after loading the module. #13 